### PR TITLE
support Swift constructors

### DIFF
--- a/Sources/perfectapigen/main.swift
+++ b/Sources/perfectapigen/main.swift
@@ -164,6 +164,8 @@ func processAPISubstructure(_ substructures: [Any]) -> [[String:Any]]? {
 			return "static func"
 		case "source.lang.swift.decl.function.subscript":
 			return "subscript"
+		case "source.lang.swift.decl.function.constructor":
+			return "func"
 		case "source.lang.swift.decl.function.free":
 			return "func"
 		case "source.lang.swift.decl.enum":


### PR DESCRIPTION
This fixes an error when parsing the Perfect-Filemaker sources:
```
$ .build/debug/perfectapigen --root ~/Developer/PerfectlySoft --dest ~/Desktop/api.html --template api_html.mustache
Working in: PerfectLib/
Working in: Perfect-CURL/
Working in: Perfect-Filemaker/
fatal error: Unknown type source.lang.swift.decl.function.constructor: file /Users/eric/Desktop/PerfectAPIGenerator/Sources/perfectapigen/main.swift, line 176
Current stack trace:
0    libswiftCore.dylib                 0x0000000107ce3cc0 swift_reportError + 132
1    libswiftCore.dylib                 0x0000000107d00f50 _swift_stdlib_reportFatalErrorInFile + 112
2    libswiftCore.dylib                 0x0000000107caf370 partial apply for (_assertionFailed(StaticString, String, StaticString, UInt, flags : UInt32) -> Never).(closure #1).(closure #1).(closure #1) + 99
3    libswiftCore.dylib                 0x0000000107af70a0 specialized specialized StaticString.withUTF8Buffer<A> ((UnsafeBufferPointer<UInt8>) -> A) -> A + 355
4    libswiftCore.dylib                 0x0000000107caf2b0 partial apply for (_assertionFailed(StaticString, StaticString, StaticString, UInt, flags : UInt32) -> Never).(closure #1).(closure #1) + 144
5    libswiftCore.dylib                 0x0000000107af75b0 specialized specialized String._withUnsafeBufferPointerToUTF8<A> ((UnsafeBufferPointer<UInt8>) throws -> A) throws -> A + 124
6    libswiftCore.dylib                 0x0000000107c53af0 partial apply for (_assertionFailed(StaticString, String, StaticString, UInt, flags : UInt32) -> Never).(closure #1) + 185
7    libswiftCore.dylib                 0x0000000107af70a0 specialized specialized StaticString.withUTF8Buffer<A> ((UnsafeBufferPointer<UInt8>) -> A) -> A + 355
8    libswiftCore.dylib                 0x0000000107af6e80 _assertionFailed(StaticString, String, StaticString, UInt, flags : UInt32) -> Never + 144
9    perfectapigen                      0x00000001075050a0 (processAPISubstructure([Any]) -> [[String : Any]]?).(getType #1)(String) -> String + 5028
10   perfectapigen                      0x00000001074ffa00 processAPISubstructure([Any]) -> [[String : Any]]? + 9267
11   perfectapigen                      0x00000001075064a0 processAPIInfo(projectName : String, apiInfo : [Any]) -> [[String : Any]] + 1616
12   perfectapigen                      0x00000001074fa500 main + 9013
13   libdyld.dylib                      0x00007fff8c8025ac start + 1
Illegal instruction: 4
$ sourcekitten version
0.15.0
```